### PR TITLE
feat: rebrand to Tomato Timer 🍅

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,20 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     
     <!-- SEO Meta Tags -->
-    <meta name="description" content="Free Pomodoro timer PWA with task management, project organization, and progress tracking. Works offline. No signup required." />
+    <meta name="description" content="Free Tomato Timer PWA with task management, project organization, and progress tracking. Works offline. No signup required." />
     <meta name="keywords" content="pomodoro, timer, productivity, task management, focus, PWA, offline" />
     <meta name="author" content="Amanda Edades" />
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Pomodoro Timer - Focus & Task Management" />
-    <meta property="og:description" content="Free Pomodoro timer with task management, project organization, and progress tracking. Works offline." />
+    <meta property="og:title" content="Tomato Timer - Focus & Task Management" />
+    <meta property="og:description" content="Free Tomato Timer with task management, project organization, and progress tracking. Works offline." />
     <meta property="og:image" content="/icons/icon-512.svg" />
     
     <!-- Twitter -->
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Pomodoro Timer - Focus & Task Management" />
-    <meta name="twitter:description" content="Free Pomodoro timer with task management, project organization, and progress tracking. Works offline." />
+    <meta name="twitter:title" content="Tomato Timer - Focus & Task Management" />
+    <meta name="twitter:description" content="Free Tomato Timer with task management, project organization, and progress tracking. Works offline." />
     <meta name="twitter:image" content="/icons/icon-512.svg" />
     
     <!-- PWA Meta Tags -->
@@ -30,7 +30,7 @@
     <link rel="manifest" href="/manifest.json" />
     <link rel="canonical" href="https://yourdomain.com/" />
     
-    <title>Pomodoro Timer - Focus & Task Management</title>
+    <title>Tomato Timer - Focus & Task Management</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "Pomodoro Timer - Focus & Task Management",
-  "short_name": "Pomodoro",
-  "description": "Free Pomodoro timer with task management, project organization, and progress tracking. Works offline. No signup required.",
+  "name": "Tomato Timer - Focus & Task Management",
+  "short_name": "Tomato Timer",
+  "description": "Free Tomato Timer with task management, project organization, and progress tracking. Works offline. No signup required.",
   "start_url": "/",
   "scope": "/",
   "display": "standalone",

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header({ settings, onUpdateSettings }: HeaderProps) {
     <header className="flex items-center justify-between mb-6">
       <div className="flex items-center gap-3">
         <span className="text-3xl">🍅</span>
-        <h1 className="text-2xl font-bold text-white dark:text-gray-100">Pomodoro</h1>
+        <h1 className="text-2xl font-bold text-white dark:text-gray-100">🍅 Tomato Timer</h1>
       </div>
 
       <div className="flex items-center gap-3">


### PR DESCRIPTION
## Changes
- Site header: **🍅 Tomato Timer**
- Page title: **Tomato Timer - Focus & Task Management**
- PWA name: **Tomato Timer**
- Updated all meta tags (OG, Twitter, description)

The name is friendlier while keeping the Pomodoro Technique reference in the Help modal.

## Custom Domain
For a nicer URL, consider buying a domain like:
- `tomatotimer.app`
- `tomato-timer.com`
- `tinytomato.app`

Then connect it: Firebase Console → Hosting → Add custom domain