### PR TITLE
feat: add Timezone Buddy link to footer

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,7 +201,7 @@ function AppContent() {
           <p className="text-white/50 dark:text-gray-500 mt-3">
             Working with a remote team? Try{' '}
             <a
-              href="https://timezone-buddy.com"
+              href="https://aedades.github.io/timezone-buddy/"
               target="_blank"
               rel="noopener noreferrer"
               className="underline hover:text-white dark:hover:text-gray-300 transition-colors"


### PR DESCRIPTION
Adds a subtle recommendation for [Timezone Buddy](https://timezone-buddy.com) in the footer, for users working with remote teams.

## Changes
- Added link below the 'Buy me a coffee' button
- Styled to match existing footer aesthetic