### PR TITLE
fix: add Firebase config for production builds

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,9 @@
+# Firebase Configuration (safe to commit - client-side config)
+# Security is enforced by Firestore rules and domain restrictions, not API key secrecy
+VITE_FIREBASE_API_KEY=AIzaSyAuudWN4HFQUTBihg9x2-PZYVMg11Fvjc8
+VITE_FIREBASE_AUTH_DOMAIN=pomopal-f14e0.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=pomopal-f14e0
+VITE_FIREBASE_STORAGE_BUCKET=pomopal-f14e0.firebasestorage.app
+VITE_FIREBASE_MESSAGING_SENDER_ID=883619358815
+VITE_FIREBASE_APP_ID=1:883619358815:web:d691ca009a58f6057353ea
+VITE_FIREBASE_VAPID_KEY=BBCARBMdSJa_2PDAehYSV6rlcJg3pHAyfBpAf5tpJZ344nRq-S2f1BuhbPaCyCcM5kULw1BbDfWd8WLe3vtsXN0


### PR DESCRIPTION
## Problem
Google Sign-In doesn't work on production because the Firebase config env vars aren't available at build time.

## Solution
Add `.env.production` with Firebase client config. This is **safe to commit** because:
- Firebase client config is designed to be public
- Security is enforced by Firestore rules (users can only access their own data)
- API key is restricted by domain in Firebase Console

Vite automatically loads `.env.production` during production builds.

## After merging
Re-run the deploy-production workflow to deploy with the fix.