### PR TITLE
debug: add logging to task creation

### DIFF
--- a/frontend/src/context/TaskContext.tsx
+++ b/frontend/src/context/TaskContext.tsx
@@ -112,8 +112,9 @@ export function TaskProvider({ children }: { children: ReactNode }) {
   }))
 
   const addTask = useCallback((title: string, projectId?: string, estimate = 1, dueDate?: string) => {
+    console.log('[TaskContext] addTask called:', { title, isCloudSync, userId: user?.id })
     dataSource.addTask(title, projectId, estimate, dueDate)
-  }, [dataSource])
+  }, [dataSource, isCloudSync, user?.id])
 
   const updateTask = useCallback((id: string, updates: Partial<Task>) => {
     // Only include properties that were explicitly provided in updates

--- a/frontend/src/hooks/useFirestoreData.ts
+++ b/frontend/src/hooks/useFirestoreData.ts
@@ -91,7 +91,11 @@ export function useFirestoreData(userId: string | null) {
   const generateId = () => crypto.randomUUID()
 
   const addTask = useCallback(async (title: string, projectId?: string, estimatedPomodoros = 1, dueDate?: string) => {
-    if (!userId || !db) return null
+    console.log('[Firestore] addTask called:', { userId, hasDb: !!db, title })
+    if (!userId || !db) {
+      console.warn('[Firestore] addTask early return - userId:', userId, 'db:', !!db)
+      return null
+    }
     
     const newTask: GuestTask = {
       id: generateId(),
@@ -105,10 +109,12 @@ export function useFirestoreData(userId: string | null) {
     }
 
     try {
+      console.log('[Firestore] Writing task to:', `users/${userId}/tasks/${newTask.id}`)
       await setDoc(doc(db, 'users', userId, 'tasks', newTask.id), newTask)
+      console.log('[Firestore] Task written successfully:', newTask.id)
       return newTask
     } catch (error) {
-      console.error('Error adding task:', error)
+      console.error('[Firestore] Error adding task:', error)
       return null
     }
   }, [userId])


### PR DESCRIPTION
Temporary debug logging to troubleshoot task creation issue when signed in.

Check browser console for:
- `[TaskContext] addTask called` - shows if context receives the call
- `[Firestore] addTask called` - shows if Firestore hook receives it
- `[Firestore] addTask early return` - shows if userId/db is missing
- `[Firestore] Writing task to` - shows the write attempt
- `[Firestore] Task written successfully` - confirms write succeeded
- `[Firestore] Error adding task` - shows any errors